### PR TITLE
Use glamor with x11 modesetting driver

### DIFF
--- a/overlays/install-overlay/usr/local/share/X11/xorg.conf.d/20-intel.conf
+++ b/overlays/install-overlay/usr/local/share/X11/xorg.conf.d/20-intel.conf
@@ -1,5 +1,5 @@
 Section "Device"
         Identifier  "Intel"
         Driver      "modesetting"
-        Option      "AccelMethod"               "uxa"
+        Option      "AccelMethod"               "glamor"
 EndSection

--- a/xtrafiles/local/share/X11/xorg.conf.d/20-intel.conf
+++ b/xtrafiles/local/share/X11/xorg.conf.d/20-intel.conf
@@ -1,6 +1,6 @@
 Section "Device"
         Identifier  "Intel"
         Driver      "modesetting"
-        Option      "AccelMethod"               "uxa"
-        Option      "SWcursor"	                "true"
+        Option      "AccelMethod"               "glamor"
+        Option      "SWcursor"                  "true"
 EndSection


### PR DESCRIPTION
The uxa value doesn't make any sense for modesetting driver and has the effect of no 2d acceleration.  That may be okay for moving the linuxkpi work along while still giving a usable desktop, but I think the intent here was to test some level of accel.  Based on #freebsd-xorg chatter, using modesetting and glamor will have artifacts on at least some gpu generations.