### PR TITLE
Update GTK_IM_MODULE_FILE variable for newer Gtk+2.

### DIFF
--- a/xtrafiles/local/share/trueos/desktop-defaults/usr/local/share/trueos/xstartup/enable-ibus.sh
+++ b/xtrafiles/local/share/trueos/desktop-defaults/usr/local/share/trueos/xstartup/enable-ibus.sh
@@ -55,7 +55,7 @@ then
 
   # For PBI applications
   GTK_IM_MODULE="xim" ; export GTK_IM_MODULE
-  GTK_IM_MODULE_FILE=/usr/local/etc/gtk-2.0/gtk.immodules ; export GTK_IM_MODULE_FILE
+  GTK_IM_MODULE_FILE=/usr/local/lib/gtk-2.0/2.10.0/immodules.cache ; export GTK_IM_MODULE_FILE
   /usr/local/bin/ibus-daemon --xim &
 
   # Enable GDK_NATIVE_WINDOWS


### PR DESCRIPTION
This pull request set with: "[Pull Request #5 · trueos/trueos-desktop](https://github.com/trueos/trueos-desktop/pull/5)"

Reference:
* [gtk-query-immodules-2.0: GTK+ 2 Reference Manual](https://developer.gnome.org/gtk2/stable/gtk-query-immodules-2.0.html)
* [[gtk+/gtk-2-24] Bug Bug 703789 - gtk.immodules still referenced](https://mail.gnome.org/archives/commits-list/2013-July/msg07694.html)