### PR TITLE
add GNUTLS option to nullmailer

### DIFF
--- a/build-files/conf/desktop/port-make.conf
+++ b/build-files/conf/desktop/port-make.conf
@@ -96,6 +96,7 @@ mail_fetchmail_SET=GSSAPI_NONE
 mail_fetchmail_UNSET= GSSAPI_BASE
 mail_mu_SET=MU4E
 mail_mutt_SET=ASPELL GPGME SMTP TRASH_PATCH NNTP SIDEBAR_PATCH
+mail_nullmailer_SET=GNUTLS
 mail_postfix_SET=MYSQL TLS DOVECOT SASL2
 mail_sylpheed_SET=GPGME
 mail_thunderbird_SET=GTK3


### PR DESCRIPTION
Most mailservers should be using TLS nowadays so not supporting TLS is a security risk