### PR TITLE
set BUNDLED_SSL on www/node4 as well.

### DIFF
--- a/build-files/conf/desktop/port-make.conf
+++ b/build-files/conf/desktop/port-make.conf
@@ -170,6 +170,7 @@ sysutils_xcdroast_SET=NONROOT
 textproc_rasqal_SET=MPFR
 www_aria2_SET=CA_BUNDLE
 www_node_SET=BUNDLED_SSL
+www_node4_SET=BUNDLED_SSL
 www_nginx_SET=HTTP_FLV HTTP_SSL PASSENGER
 www_redmine_SET=POSTGRESQL PASSENGER
 www_redmine_UNSET=THIN


### PR DESCRIPTION
www/node4 is the LTS version of Node.js. Like www/node, it won't build with LibreSSL.