### PR TITLE
Improve build options for password-store

### DIFF
--- a/build-files/conf/desktop/port-make.conf
+++ b/build-files/conf/desktop/port-make.conf
@@ -162,6 +162,7 @@ sysutils_graveman_SET=MP3 OGG DVD
 sysutils_grub2-pcbsd_SET=MKFONT FUSE
 sysutils_hal_SET=FIXED_MOUNTPOINTS
 sysutils_k3b-kde4_SET=SOX NORMALIZE TRANSCODE
+sysutils_password-store_SET=CONTRIB GIT XCLIP
 sysutils_pefs-kmod_SET=AESNI
 sysutils_testdisk_SET=NTFS NTFS3G
 sysutils_ucspi-tcp_SET=SSL


### PR DESCRIPTION
This adds git and xclip support to password-store, without which it's fairly crippled (git gives it source control, and xclip makes it so that it's possible to temporarily copy passwords to the clipboard).

Hopefully, I got the syntax and whatnot right, since I've never messed with this file before and have only ever configured password-store via make config.

If I understand correctly, CONTRIB should already be the default (it adds stuff like shell support and various importer scripts), but I'm assuming that all of the options need to be listed, which is why it's also in the list.