### PR TITLE
Fi x it so that phantomjs is built with X support again.

### DIFF
--- a/build-files/conf/desktop/port-make.conf
+++ b/build-files/conf/desktop/port-make.conf
@@ -86,6 +86,7 @@ lang_gcc_SET=JAVA
 lang_gcc47_SET=JAVA
 lang_gcc48_SET=JAVA
 lang_gcc49_SET=JAVA
+lang_phantomjs_SET=X11
 lang_php5_SET=APACHE FPM
 lang_sbcl_SET=THREADS
 mail_claws-mail_SET=BOGOFILTER GPGME SPAMASSASSIN


### PR DESCRIPTION
It was semi-recently changed in the official FreeBSD ports tree so that phantomjs isn't built with X support by default anymore, but X support is needed for stuff like taking screenshots. So, this re-enables X support for phantomjs for TrueOS.