### PR TITLE
Fix bug where disabled service gets re-enabled

### DIFF
--- a/xtrafiles/local/bin/migrate_rc_openrc
+++ b/xtrafiles/local/bin/migrate_rc_openrc
@@ -15,6 +15,7 @@ do
       echo "Deleting OpenRC service for $key to default runlevel..."
       rc-update delete $key default
   fi
+  if [ "$val" = "NO" ] ; then continue; fi
   if [ -e "/etc/init.d/$key" -o -e "/usr/local/etc/init.d/$key" ] ; then
     if [ -e "/etc/runlevels/default/$key" ] ; then
       echo "OpenRC service for $key already enabled, skipping.."


### PR DESCRIPTION
This happened to me when I disabled PCDM with `pcdm_enable="NO"` in `/etc/rc.conf`.  The first time the migrate script saw this, it would run the `rc-update delete` command on line 16, then hit the subsequent lines and *re-enable* the service (via the `rc-update add` on line 24 (old line 23))!  Ha!  This fix, by adding short-circuiting logic, should stop that from happening.