### PR TITLE
be liberal about where pc-autoinstall.conf and pc-sysinstall.conf are placed

### DIFF
--- a/overlays/install-overlay/etc/SetupInstall.sh
+++ b/overlays/install-overlay/etc/SetupInstall.sh
@@ -21,10 +21,10 @@ if [ -e "/dist/no-install-pkgs" ] ; then touch /tmp/no-install-pkgs ; fi
 if [ -e "/dist/no-fbsd-release" ] ; then touch /tmp/no-fbsd-release ; fi
 
 # Check if we have a pc-autoinstall.conf file
-if [ -e "/boot/pc-autoinstall.conf" ]
+if [ -e "/boot/pc-autoinstall.conf" -o -e "/pc-autoinstall.conf" ]
 then
   # We have one, copy it over so that pc-sysinstall can parse it later during the bootup
-  cp /boot/pc-autoinstall.conf /tmp/pc-autoinstall.conf
+  cp /boot/pc-autoinstall.conf /tmp/pc-autoinstall.conf > /dev/null 2>/dev/null || cp /pc-autoinstall.conf /tmp/pc-autoinstall.conf
   
   # Check if the config file is on disk as well
   PCCFG=`grep "pc_config:" /tmp/pc-autoinstall.conf | grep -v "^#" | /bin/cut -d ':' -f 2 | tr -d ' '`
@@ -35,7 +35,9 @@ then
   then
     if [ -e "/${PCCFG}" ]
     then
-      cp /${PCCFG} /tmp/pc-sysinstall.cfg
+      cp /${PCCFG} /tmp/pc-sysinstall.conf
+	  # adjust path to pc-sysinstall.conf to where we just copied it, so pc-sysinstall can parse it later
+	  sed -i '' "s|${PCCFG}|/tmp/pc-sysinstall.conf|" /tmp/pc-autoinstall.conf
     else
       echo "ERROR: pc_config: ${PCCFG} isn't on the boot media! Automated install aborted!"
       rm /tmp/pc-autoinstall.conf

--- a/overlays/install-overlay/etc/SetupInstall.sh
+++ b/overlays/install-overlay/etc/SetupInstall.sh
@@ -35,9 +35,9 @@ then
   then
     if [ -e "/${PCCFG}" ]
     then
-      cp /${PCCFG} /tmp/pc-sysinstall.conf
-	  # adjust path to pc-sysinstall.conf to where we just copied it, so pc-sysinstall can parse it later
-	  sed -i '' "s|${PCCFG}|/tmp/pc-sysinstall.conf|" /tmp/pc-autoinstall.conf
+      cp /${PCCFG} /tmp/pc-sysinstall.cfg
+	  # adjust path to pc-sysinstall.cfg to where we just copied it, so pc-sysinstall can parse it later
+	  sed -i '' "s|${PCCFG}|/tmp/pc-sysinstall.cfg|" /tmp/pc-autoinstall.conf
     else
       echo "ERROR: pc_config: ${PCCFG} isn't on the boot media! Automated install aborted!"
       rm /tmp/pc-autoinstall.conf

--- a/overlays/install-overlay/root/TrueOSStart.sh
+++ b/overlays/install-overlay/root/TrueOSStart.sh
@@ -88,10 +88,10 @@ if [ -e "/trueos-server" ] ; then
 fi
 
 # Check if we have an auto-install directive
-if [ -e "/pc-autoinstall.conf" ]
+if [ -e "/tmp/pc-autoinstall.conf" ]
 then
   # Start the parser on this directive and begin the install
-  /root/pc-sysinstall/pc-sysinstall start-autoinstall /pc-autoinstall.conf
+  /root/pc-sysinstall/pc-sysinstall start-autoinstall /tmp/pc-autoinstall.conf
 fi
 
 # Run the intial sorting of directories


### PR DESCRIPTION
be liberal about where pc-autoinstall.conf and pc-sysinstall.conf are placed

SetupInstall.sh probed for pc-autoinstall.conf in /boot and copied it to
/tmp. Then it checks for the pc-sysinstall.conf file at the path specified in
pc-autoinstall.conf and also copy it to /tmp or aborts with an error

TrueOSStart.sh would assume to find pc-autoinstall.conf at the
filesystem root, not in /tmp where it was put by SetupInstall. Therefore
it is possible that pc-sysinstall.conf might no longer be accessible due
to mounts/overlays during boot and initial setup of the installer
environment.

With this fix SetupInstall.sh copies pc-autoinstall.conf from either "/" or
"/boot" to "/tmp" as well as the pc-sysinstall.conf (if present).
The path to pc-sysinstall.conf within pc-autoinstall.conf is also modified
to read it from /tmp.